### PR TITLE
Potential fix for code scanning alert no. 8: Missing rate limiting

### DIFF
--- a/03_repo/app.js
+++ b/03_repo/app.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const mysql = require('mysql2');
 const fs = require('fs');
+const rateLimit = require('express-rate-limit');
 
 const app = express();
 app.use(express.json());
@@ -37,7 +38,14 @@ app.post('/api/products', (req, res) => {
   });
 });
 
-app.get('/api/files/:filename', (req, res) => {
+// Rate limiter for file access route
+const filesLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  message: { error: 'Too many requests, please try again later.' }
+});
+
+app.get('/api/files/:filename', filesLimiter, (req, res) => {
   const filename = req.params.filename;
   const filePath = `./uploads/${filename}`;
   

--- a/03_repo/package.json
+++ b/03_repo/package.json
@@ -17,7 +17,8 @@
     "winston": "3.2.1",
     "moment": "2.24.0",
     "request": "2.88.0",
-    "axios": "0.18.0"
+    "axios": "0.18.0",
+    "express-rate-limit": "^8.1.0"
   },
   "devDependencies": {
     "nodemon": "1.19.1"


### PR DESCRIPTION
Potential fix for [https://github.com/GitHub-PaloIT-Lab/th_ghcp_ktb_workshop_3/security/code-scanning/8](https://github.com/GitHub-PaloIT-Lab/th_ghcp_ktb_workshop_3/security/code-scanning/8)

To fix the issue, we should add a rate limiting middleware to the `/api/files/:filename` route. The recommended way is to use a well-known package such as `express-rate-limit`. This can be imported and configured to limit requests: for example, a maximum of 100 requests per 15 minutes from any single IP. You need to (1) import `express-rate-limit`, (2) configure a limiter, and (3) apply the limiter middleware to the affected route. Edits are all within `03_repo/app.js`—specifically, insert the import, limiter configuration, and ensure the `/api/files/:filename` route uses it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
